### PR TITLE
Add Oracle for Discord Server Structure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+.vscode/
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/ORACLE.md
+++ b/ORACLE.md
@@ -27,13 +27,14 @@ See example below:
 ### Community Tools
 These are tools provided by discord that can help both users and moderators to find information about events, channels and members. 
 - **Events**
-  > Only users who have the "Create Events" or "Manage Events" permissions are allowed to see this tool by default. If there is a planned event or ongoing event, then everyone will be able to see button with additional information.
+  > Only users who have the "Create Events" or "Manage Events" permissions are allowed to see this tool by default. If there is a planned event or ongoing event, then everyone will be able to see the button with additional information.
 - **Browse Channels**
   > Everyone is allowed to browse channels of the Discord Server. It is an accessibility tool intended for massive community servers with personalization. Our server is **not** intended to be massive by any means, the feature is redundant for our use case.  
   > Browse Channels do support "Onboarding" which is accessible through `Server Settings > Community > Onboarding` or by right-clicking "Browse Channels" button and then "Edit Onboarding".  
   > Onboarding is a discord feature that lets newcomers be guided through the personalization process and incentivizes a first chat message. Onboarding could be a replacement for a traditional **#roles** channel. 
 - **Members**
-  > 
+  > The Members Page is a tool for moderators and admins to manage members of the server. Discord gives access to the tool if a user has at least one of the following permissions: administrator, manage server, manage roles, manage nicknames, ban members, timeout members, or kick members.  
+  > This tool can be useful for changing previous students to alumni after a summer break. For more information regarding the tool, visit [support.discord.com](https://support.discord.com/hc/en-us/articles/15946797617431-Members-Page).
 
 ### Server Structure Oracle
 - **`INFORMATION`**
@@ -59,19 +60,21 @@ These are tools provided by discord that can help both users and moderators to f
 - **`STUDY`**
   - **software-engineering**
   - **other-program-overview**
-    > Dedicated channels for students to see their program overview of courses. The channel is read only and is managed by admins through discord-bot commands. Only the users with the specific `@program` role will have access to their dedicated channel. Unless they toggle the reaction message in `#all-courses`.
+    > Dedicated channels for students to see their program overview of courses. The channel is read only and is managed by admins through discord-bot commands. Only the users with the specific `@program` role will have access to their dedicated channel. The last message will always be a reaction message to toggle visibility of all program overviews.
   - ***all-courses***
     - *XX0000 - Web programming*
     - *XX0000 - Introduction to software*
     - *Etc*
-        > A dedicated channel for all university courses that are relevant to our discord server. This will act as a registry for any student user to look for struggles and solutions from previous students. Only the discord-bot will manage this channel by creating threads based on program overviews defined above. The last message will always be a reaction message to toggle visibility of all program overviews.
+        > A dedicated channel for all university courses that are relevant to our discord server. This will act as a registry for any student user to look for struggles and solutions from previous students. Only the discord-bot will manage this channel by creating threads based on program overviews defined above. The last message will always be instructions on how to use Discord's search threads function in the top right corner.
 - **`RODENTS`**
+  - **general**
   - **lab-suggestions**
     > A forum to discuss how to improve the lab
-  - **general**
-  - ***meeting-notes***
-    - *2024-08-12*
-        > A discord-bot managed channel to write meeting notes in.
+  - **happenings**
+    - *Robotics Workshop*
+    - *Open House*
+    - *Lab Meeting 2024-08-13*
+        > A channel that acts as both announcements and events in one. Admins can announce upcoming meetings. Moderators can create threads to plan upcoming happenings. Here lies an opportunity for the discord bot to summarize past meetings to create an opening speech for a new meeting. Perhaps `/meeting` is a suitable command.
   - **announcements** (Subscribed to discord newsletter)
     > Mainly a channel for admins to see new discord features, maybe can be applied on a thread or removed as the channel itself won't be too useful.
 

--- a/ORACLE.md
+++ b/ORACLE.md
@@ -35,3 +35,43 @@ These are tools provided by discord that can help both users and moderators to f
 - **Members**
   > 
 
+### Server Structure Oracle
+- **`INFORMATION`**
+  - **rules**
+    > Includes opening hours, what food to bring, the user must behave well, etc. The user needs to accept the terms to access the discord server.
+  - **announcements**
+  - **links**
+  - **roles**
+    > Could be replaced with *Onboarding* from [Community Tools](#community-tools)
+- **`GENERAL`**
+  - **general**
+  - **memes**
+  - ***discussions***
+    - *Games to buy*
+    - *Any plans to hold a movie night?*
+    - *Etc*
+        > A thread channel dedicated to discussions, anyone can create a thread in that channel and the discord bot may reformat the thread to be "`@user` wish to discuss about `#Games to buy`". (Subject to change, it is a very long message for it to be spammed in a single channel).
+- **`HELP`**
+  - **lab-access**
+  - **loan-equipment**
+    > A channel dedicated for discord-bot to manage renting equipment. It is read only but admins can send a command for the discord-bot to keep track of responsibility and return date.
+  - 
+- **`STUDY`**
+  - **software-engineering**
+  - **other-programme-overview**
+    > Dedicated channels for students to see their programme overview of courses. The channel is read only and is managed by admins through discord-bot commands. Only the users with the spacific `@programme` role will have access to their dedicated channel. Unless they toggle the reaction message in `#all-courses`.
+  - ***all-courses***
+    - *XX0000 - Web programming*
+    - *XX0000 - Introduction to software*
+    - *Etc*
+        > A dedicated channel for all university courses that are relevant to our discord server. This will act as a registry for any student user to look for struggles and solutions from previous students. Only the discord-bot will manage this channel by creating threads based on programme overviews defined above. The last message will always be a reaction message to toggle visibility of all programme overviews.
+- **`RODENTS`**
+  - **lab-suggestions**
+    > A forum to discuss how to improve the lab
+  - **general**
+  - ***meeting-notes***
+    - *2024-08-12*
+        > A discord-bot managed channel to write meeting notes in.
+  - **announcements** (Subscribed to discord newsletter)
+    > Mainly a channel for admins to see new discord features, maybe can be applied on a thread or removed as the channel itself won't be too useful.
+

--- a/ORACLE.md
+++ b/ORACLE.md
@@ -33,7 +33,7 @@ These are tools provided by discord that can help both users and moderators to f
 - **Browse Channels**
   > Everyone is allowed to browse channels of the Discord Server. It is an accessibility tool intended for massive community servers with personalization. Our server is **not** intended to be massive by any means, the feature is redundant for our use case.
   > Browse Channels do support "Onboarding" which is accessible through `Server Settings > Community > Onboarding` or by right-clicking "Browse Channels" button and then "Edit Onboarding".
-  > Onboarding is a discord feature that lets newcomers be guided through the personalization process and incentivizes a first chat message. Onboarding could be a replacement for a traditional **#roles** channel.
+  > Onboarding is a discord feature that lets newcomers be guided through the personalization process and incentivize a first chat message. Onboarding could be a replacement for a traditional **#roles** channel.
 - **Members**
   > The Members Page is a tool for moderators and admins to manage members of the server. Discord gives access to the tool if a user has at least one of the following permissions: administrator, manage server, manage roles, manage nicknames, ban members, timeout members, or kick members.
   > This tool can be useful for changing previous students to alumni after a summer break. For more information regarding the tool, visit [support.discord.com](https://support.discord.com/hc/en-us/articles/15946797617431-Members-Page).

--- a/ORACLE.md
+++ b/ORACLE.md
@@ -6,75 +6,76 @@ This document defines structures for how the Discord Server shall be configured.
 
 ### Formatting
 
-Categories (which acts like folders) are defined as `Markdown code brackets`.  
-Channel for chatting is defined with **Markdown bold**.  
-Thread for temporary chatting is defined with *Markdown italics*  
-A channel only used for threads is defined with ***Markdown bold italics***.  
-Comments are defined as `> Markdown quotes`.  
+Categories (which acts like folders) are defined as `Markdown code brackets`.
+Channel for chatting is defined with **Markdown bold**.
+Thread for temporary chatting is defined with _Markdown italics_
+A channel only used for threads is defined with **_Markdown bold italics_**.
+Comments are defined as `> Markdown quotes`.
 See example below:
 
 - **`CATEGORY`**
   > Comment on category
   - **Channel**
     > Comment about channel
-  - ***Thread Exclusive Channel***
-    - *Thread name example 1*
-    - *Example 2*
-        > Comment on individual thread or the thread channel as a whole
+  - **_Thread Exclusive Channel_**
+    - _Thread name example 1_
+    - _Example 2_
+      > Comment on individual thread or the thread channel as a whole
   - **Channel-2**
   - ...
 
 ### Community Tools
-These are tools provided by discord that can help both users and moderators to find information about events, channels and members. 
+
+These are tools provided by discord that can help both users and moderators to find information about events, channels and members.
+
 - **Events**
   > Only users who have the "Create Events" or "Manage Events" permissions are allowed to see this tool by default. If there is a planned event or ongoing event, then everyone will be able to see the button with additional information.
 - **Browse Channels**
-  > Everyone is allowed to browse channels of the Discord Server. It is an accessibility tool intended for massive community servers with personalization. Our server is **not** intended to be massive by any means, the feature is redundant for our use case.  
-  > Browse Channels do support "Onboarding" which is accessible through `Server Settings > Community > Onboarding` or by right-clicking "Browse Channels" button and then "Edit Onboarding".  
-  > Onboarding is a discord feature that lets newcomers be guided through the personalization process and incentivizes a first chat message. Onboarding could be a replacement for a traditional **#roles** channel. 
+  > Everyone is allowed to browse channels of the Discord Server. It is an accessibility tool intended for massive community servers with personalization. Our server is **not** intended to be massive by any means, the feature is redundant for our use case.
+  > Browse Channels do support "Onboarding" which is accessible through `Server Settings > Community > Onboarding` or by right-clicking "Browse Channels" button and then "Edit Onboarding".
+  > Onboarding is a discord feature that lets newcomers be guided through the personalization process and incentivizes a first chat message. Onboarding could be a replacement for a traditional **#roles** channel.
 - **Members**
-  > The Members Page is a tool for moderators and admins to manage members of the server. Discord gives access to the tool if a user has at least one of the following permissions: administrator, manage server, manage roles, manage nicknames, ban members, timeout members, or kick members.  
+  > The Members Page is a tool for moderators and admins to manage members of the server. Discord gives access to the tool if a user has at least one of the following permissions: administrator, manage server, manage roles, manage nicknames, ban members, timeout members, or kick members.
   > This tool can be useful for changing previous students to alumni after a summer break. For more information regarding the tool, visit [support.discord.com](https://support.discord.com/hc/en-us/articles/15946797617431-Members-Page).
 
 ### Server Structure Oracle
+
 - **`INFORMATION`**
   - **rules**
     > Includes opening hours, what food to bring, the user must behave well, etc. The user needs to accept the terms to access the discord server.
   - **announcements**
   - **links**
   - **roles**
-    > Could be replaced with *Onboarding* from [Community Tools](#community-tools)
+    > Could be replaced with _Onboarding_ from [Community Tools](#community-tools)
 - **`GENERAL`**
   - **general**
   - **memes**
-  - ***discussions***
-    - *Games to buy*
-    - *Any plans to hold a movie night?*
-    - *Etc*
-        > A thread channel dedicated to discussions, anyone can create a thread in that channel and the discord bot may reformat the thread to be "`@user` wish to discuss about `#Games to buy`". (Subject to change, it is a very long message for it to be spammed in a single channel).
+  - **_discussions_**
+    - _Games to buy_
+    - _Any plans to hold a movie night?_
+    - _Etc_
+      > A thread channel dedicated to discussions, anyone can create a thread in that channel and the discord bot may reformat the thread to be "`@user` wish to discuss about `#Games to buy`". (Subject to change, it is a very long message for it to be spammed in a single channel).
 - **`HELP`**
   - **lab-access**
   - **loan-equipment**
     > A channel dedicated for discord-bot to manage renting equipment. It is read only, but admins can send a command for the discord-bot to keep track of responsibility and return date.
-  - 
 - **`STUDY`**
   - **software-engineering**
   - **other-program-overview**
     > Dedicated channels for students to see their program overview of courses. The channel is read only and is managed by admins through discord-bot commands. Only the users with the specific `@program` role will have access to their dedicated channel. The last message will always be a reaction message to toggle visibility of all program overviews.
-  - ***all-courses***
-    - *XX0000 - Web programming*
-    - *XX0000 - Introduction to software*
-    - *Etc*
-        > A dedicated channel for all university courses that are relevant to our discord server. This will act as a registry for any student user to look for struggles and solutions from previous students. Only the discord-bot will manage this channel by creating threads based on program overviews defined above. The last message will always be instructions on how to use Discord's search threads function in the top right corner.
+  - **_all-courses_**
+    - _XX0000 - Web programming_
+    - _XX0000 - Introduction to software_
+    - _Etc_
+      > A dedicated channel for all university courses that are relevant to our discord server. This will act as a registry for any student user to look for struggles and solutions from previous students. Only the discord-bot will manage this channel by creating threads based on program overviews defined above. The last message will always be instructions on how to use Discord's search threads function in the top right corner.
 - **`RODENTS`**
   - **general**
   - **lab-suggestions**
     > A forum to discuss how to improve the lab
   - **happenings**
-    - *Robotics Workshop*
-    - *Open House*
-    - *Lab Meeting 2024-08-13*
-        > A channel that acts as both announcements and events in one. Admins can announce upcoming meetings. Moderators can create threads to plan upcoming happenings. Here lies an opportunity for the discord bot to summarize past meetings to create an opening speech for a new meeting. Perhaps `/meeting` is a suitable command.
+    - _Robotics Workshop_
+    - _Open House_
+    - _Lab Meeting 2024-08-13_
+      > A channel that acts as both announcements and events in one. Admins can announce upcoming meetings. Moderators can create threads to plan upcoming happenings. Here lies an opportunity for the discord bot to summarize past meetings to create an opening speech for a new meeting. Perhaps `/meeting` is a suitable command.
   - **announcements** (Subscribed to discord newsletter)
     > Mainly a channel for admins to see new discord features, maybe can be applied on a thread or removed as the channel itself won't be too useful.
-

--- a/ORACLE.md
+++ b/ORACLE.md
@@ -1,16 +1,16 @@
 # Oracle
 
-This document defines structures for how the Discord Server shall be configured. Including comments with reasoning behind selected configuration options. Acts as a backup if the Discord Server gets comprimised or an athoritized user changes unintended settings without documentation.
+This document defines structures for how the Discord Server shall be configured. Including comments with reasoning behind selected configuration options. Acts as a backup if the Discord Server gets compromised or an authorized user changes unintended settings without documentation.
 
 ## Server Structure
 
-### Formating
+### Formatting
 
-Categories (which acts like folders) are defined as `markdown code brackets`.  
-Channel for chatting is defined with **markdown bold**.  
-Thread for temporary chatting is defined with *markdown italics*  
-A channel only used for threads is defined with ***markdown bold italics***.  
-Comments are defined as `> markdown quotes`.  
+Categories (which acts like folders) are defined as `Markdown code brackets`.  
+Channel for chatting is defined with **Markdown bold**.  
+Thread for temporary chatting is defined with *Markdown italics*  
+A channel only used for threads is defined with ***Markdown bold italics***.  
+Comments are defined as `> Markdown quotes`.  
 See example below:
 
 - **`CATEGORY`**
@@ -27,11 +27,11 @@ See example below:
 ### Community Tools
 These are tools provided by discord that can help both users and moderators to find information about events, channels and members. 
 - **Events**
-  > Only users who has the "Create Events" or "Manage Events" permissions are allowed to see this tool by default. If there is a planned event or on going event, then everyone will be able to see button with additional information.
+  > Only users who have the "Create Events" or "Manage Events" permissions are allowed to see this tool by default. If there is a planned event or ongoing event, then everyone will be able to see button with additional information.
 - **Browse Channels**
-  > Everyone is allowed to browse channels of the Discord Server. It is an accessability tool intended for massive community servers with personalization. Our server is **not** intended to be massive by any means, the feature is redundant for our use case.  
-  > Browse Channels do support "Onboarding" which is accessable through `Server Settings > Community > Onboarding` or by right-clicking "Browse Channels" button and then "Edit Onboarding".  
-  > Onboarding is a discord feature that lets newcomers to be guided through the personalization process and incentivizes a first chat message. Onboarding could be a replacement for a traditional **#roles** channel. 
+  > Everyone is allowed to browse channels of the Discord Server. It is an accessibility tool intended for massive community servers with personalization. Our server is **not** intended to be massive by any means, the feature is redundant for our use case.  
+  > Browse Channels do support "Onboarding" which is accessible through `Server Settings > Community > Onboarding` or by right-clicking "Browse Channels" button and then "Edit Onboarding".  
+  > Onboarding is a discord feature that lets newcomers be guided through the personalization process and incentivizes a first chat message. Onboarding could be a replacement for a traditional **#roles** channel. 
 - **Members**
   > 
 
@@ -54,17 +54,17 @@ These are tools provided by discord that can help both users and moderators to f
 - **`HELP`**
   - **lab-access**
   - **loan-equipment**
-    > A channel dedicated for discord-bot to manage renting equipment. It is read only but admins can send a command for the discord-bot to keep track of responsibility and return date.
+    > A channel dedicated for discord-bot to manage renting equipment. It is read only, but admins can send a command for the discord-bot to keep track of responsibility and return date.
   - 
 - **`STUDY`**
   - **software-engineering**
-  - **other-programme-overview**
-    > Dedicated channels for students to see their programme overview of courses. The channel is read only and is managed by admins through discord-bot commands. Only the users with the spacific `@programme` role will have access to their dedicated channel. Unless they toggle the reaction message in `#all-courses`.
+  - **other-program-overview**
+    > Dedicated channels for students to see their program overview of courses. The channel is read only and is managed by admins through discord-bot commands. Only the users with the specific `@program` role will have access to their dedicated channel. Unless they toggle the reaction message in `#all-courses`.
   - ***all-courses***
     - *XX0000 - Web programming*
     - *XX0000 - Introduction to software*
     - *Etc*
-        > A dedicated channel for all university courses that are relevant to our discord server. This will act as a registry for any student user to look for struggles and solutions from previous students. Only the discord-bot will manage this channel by creating threads based on programme overviews defined above. The last message will always be a reaction message to toggle visibility of all programme overviews.
+        > A dedicated channel for all university courses that are relevant to our discord server. This will act as a registry for any student user to look for struggles and solutions from previous students. Only the discord-bot will manage this channel by creating threads based on program overviews defined above. The last message will always be a reaction message to toggle visibility of all program overviews.
 - **`RODENTS`**
   - **lab-suggestions**
     > A forum to discuss how to improve the lab

--- a/ORACLE.md
+++ b/ORACLE.md
@@ -1,0 +1,3 @@
+# Oracle
+
+This document defines structures for how the Discord Server shall be configured. Including comments with reasoning behind selected configuration options. Acts as a backup if the Discord Server gets comprimised or an athoritized user changes unintended settings without documentation.

--- a/ORACLE.md
+++ b/ORACLE.md
@@ -4,6 +4,8 @@ This document defines structures for how the Discord Server shall be configured.
 
 ## Server Structure
 
+### Formating
+
 Categories (which acts like folders) are defined as `markdown code brackets`.  
 Channel for chatting is defined with **markdown bold**.  
 Thread for temporary chatting is defined with *markdown italics*  
@@ -21,4 +23,15 @@ See example below:
         > Comment on individual thread or the thread channel as a whole
   - **Channel-2**
   - ...
+
+### Community Tools
+These are tools provided by discord that can help both users and moderators to find information about events, channels and members. 
+- **Events**
+  > Only users who has the "Create Events" or "Manage Events" permissions are allowed to see this tool by default. If there is a planned event or on going event, then everyone will be able to see button with additional information.
+- **Browse Channels**
+  > Everyone is allowed to browse channels of the Discord Server. It is an accessability tool intended for massive community servers with personalization. Our server is **not** intended to be massive by any means, the feature is redundant for our use case.  
+  > Browse Channels do support "Onboarding" which is accessable through `Server Settings > Community > Onboarding` or by right-clicking "Browse Channels" button and then "Edit Onboarding".  
+  > Onboarding is a discord feature that lets newcomers to be guided through the personalization process and incentivizes a first chat message. Onboarding could be a replacement for a traditional **#roles** channel. 
+- **Members**
+  > 
 

--- a/ORACLE.md
+++ b/ORACLE.md
@@ -1,3 +1,24 @@
 # Oracle
 
 This document defines structures for how the Discord Server shall be configured. Including comments with reasoning behind selected configuration options. Acts as a backup if the Discord Server gets comprimised or an athoritized user changes unintended settings without documentation.
+
+## Server Structure
+
+Categories (which acts like folders) are defined as `markdown code brackets`.  
+Channel for chatting is defined with **markdown bold**.  
+Thread for temporary chatting is defined with *markdown italics*  
+A channel only used for threads is defined with ***markdown bold italics***.  
+Comments are defined as `> markdown quotes`.  
+See example below:
+
+- **`CATEGORY`**
+  > Comment on category
+  - **Channel**
+    > Comment about channel
+  - ***Thread Exclusive Channel***
+    - *Thread name example 1*
+    - *Example 2*
+        > Comment on individual thread or the thread channel as a whole
+  - **Channel-2**
+  - ...
+

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 This repository contains everything related to the SERL Discord Server at BTH.  At the time there is some oracles for intended channel structure and role permissions, as well as a development on a discord bot. 
 
 ## Oracles
-- [ ] Add Channel Structure Oracle
+- [x] Add Channel Structure Oracle
 - [ ] Add Role Permissions Oracle
 
 ## discord-bot

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # Discord Repository
-This repository contains everything related to the SERL Discord Server at BTH.  At the time there is some oracles for intended channel structure and role permissions, as well as a development on a discord bot. 
+This repository contains everything related to the SERL Discord Server at BTH.
 
-## Oracles
-- [x] Add Channel Structure Oracle
-- [ ] Add Role Permissions Oracle
+## Oracle
+[**The Oracle**](ORACLE.md) contains intended channel structure, role permissions and functionality of the discord bot. Includes comments with reasoning behind selected features.  
+Acts as a backup if the Discord Server gets compromised or an authorized user changes unintended settings without documentation.
 
 ## discord-bot
 A simple bot to manage our SERL discord server

--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 # Discord Repository
+
 This repository contains everything related to the SERL Discord Server at BTH.
 
 ## Oracle
+
 [**The Oracle**](ORACLE.md) contains intended channel structure, role permissions and functionality of the discord bot. Includes comments with reasoning behind selected features.  
 Acts as a backup if the Discord Server gets compromised or an authorized user changes unintended settings without documentation.
 


### PR DESCRIPTION
This pull request adds an Oracle document that defines the structure for how the Discord Server should be configured. The document includes formatting guidelines for categories, channels, and threads, as well as comments with reasoning behind selected configuration options. Additionally, the pull request updates the README to refer to the Oracle document.

Read through the oracle and comment if there are any uncertainties. The oracle should be understandable enough to rebuild the discord server from scratch, if need be.